### PR TITLE
Proposed fix for json endpoint truncation

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,3 @@
 machine:
   ruby:
-    version: 2.0.0-p568
+    version: rbx-2.2.6

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,3 @@
 machine:
   ruby:
-    version: 1.9.3-p194
+    version: 2.0.0-p568

--- a/lib/dashing_api/api.rb
+++ b/lib/dashing_api/api.rb
@@ -19,7 +19,7 @@ end
 get '/tiles/:id.json' do
     content_type :json
     if data = settings.history[params[:id]]
-    	data.split[1]
+    	data.sub("data: ","")
     else
     	@message = "Host " + params[:id] + "does not exist"
     	404


### PR DESCRIPTION
When there are spaces in any of the tile/widget's fields, the json endpoint truncates prematurely.  This is a proposal to fix issue #24.
